### PR TITLE
Adds paging support for listing users and private channels.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ classes
 gradle.properties
 target
 out/
+/.env

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Slack Gateway: A tool to create a Slack channel, invite people and post a message in a single request. [![CircleCI](https://circleci.com/gh/outofcoffee/slack-gateway.svg?style=svg)](https://circleci.com/gh/outofcoffee/slack-gateway)
+# Slack Gateway: An HTTP gateway for posting to Slack [![CircleCI](https://circleci.com/gh/outofcoffee/slack-gateway.svg?style=svg)](https://circleci.com/gh/outofcoffee/slack-gateway)
+
+With a single HTTP request, you can post a message, creating the channel first if it doesn't exist and invite people and groups.
 
 ## What can it do?
 

--- a/backends/slack/src/main/kotlin/com/gatehill/slackgateway/backend/slack/exception/SlackErrorResponseException.kt
+++ b/backends/slack/src/main/kotlin/com/gatehill/slackgateway/backend/slack/exception/SlackErrorResponseException.kt
@@ -5,14 +5,16 @@ import com.gatehill.slackgateway.backend.slack.model.SlackErrorResponse
 class SlackErrorResponseException : Throwable {
     val errorResponse: SlackErrorResponse?
 
-    constructor(jsonResponse: String) : super(
-        message = "Received error response: $jsonResponse"
+    constructor(jsonResponse: String, cause: Throwable? = null) : super(
+        message = "Received error response: $jsonResponse",
+        cause = cause
     ) {
         this.errorResponse = null
     }
 
-    constructor(errorResponse: SlackErrorResponse, jsonResponse: String) : super(
-        message = "Received error response [error=${errorResponse.error}]: $jsonResponse"
+    constructor(errorResponse: SlackErrorResponse, jsonResponse: String, cause: Throwable? = null) : super(
+        message = "Received error response [error=${errorResponse.error}]: $jsonResponse",
+        cause = cause
     ) {
         this.errorResponse = errorResponse
     }

--- a/backends/slack/src/main/kotlin/com/gatehill/slackgateway/backend/slack/model/GroupsListResponse.kt
+++ b/backends/slack/src/main/kotlin/com/gatehill/slackgateway/backend/slack/model/GroupsListResponse.kt
@@ -1,9 +1,18 @@
 package com.gatehill.slackgateway.backend.slack.model
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class GroupsListResponse(
     override val ok: Boolean,
-    val groups: List<SlackGroup>?
-) : ResponseWithStatus
+
+    val groups: MutableList<SlackGroup>?,
+
+    @JsonProperty("response_metadata")
+    override val responseMetadata: ResponseMetadata?
+
+) : ResponseWithStatus, PaginatedResponse<SlackGroup> {
+    override val innerResults
+        get() = groups ?: mutableListOf()
+}

--- a/backends/slack/src/main/kotlin/com/gatehill/slackgateway/backend/slack/model/PaginatedResponse.kt
+++ b/backends/slack/src/main/kotlin/com/gatehill/slackgateway/backend/slack/model/PaginatedResponse.kt
@@ -1,0 +1,6 @@
+package com.gatehill.slackgateway.backend.slack.model
+
+interface PaginatedResponse<T> {
+    val responseMetadata: ResponseMetadata?
+    val innerResults: MutableList<T>
+}

--- a/backends/slack/src/main/kotlin/com/gatehill/slackgateway/backend/slack/model/ResponseMetadata.kt
+++ b/backends/slack/src/main/kotlin/com/gatehill/slackgateway/backend/slack/model/ResponseMetadata.kt
@@ -1,0 +1,10 @@
+package com.gatehill.slackgateway.backend.slack.model
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class ResponseMetadata(
+    @JsonProperty("next_cursor")
+    val nextCursor: String?
+)

--- a/backends/slack/src/main/kotlin/com/gatehill/slackgateway/backend/slack/model/UsersListResponse.kt
+++ b/backends/slack/src/main/kotlin/com/gatehill/slackgateway/backend/slack/model/UsersListResponse.kt
@@ -1,9 +1,18 @@
 package com.gatehill.slackgateway.backend.slack.model
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class UsersListResponse(
     override val ok: Boolean,
-    val members: List<SlackUser>
-) : ResponseWithStatus
+
+    val members: MutableList<SlackUser>,
+
+    @JsonProperty("response_metadata")
+    override val responseMetadata: ResponseMetadata?
+
+) : ResponseWithStatus, PaginatedResponse<SlackUser> {
+    override val innerResults
+        get() = members
+}

--- a/backends/slack/src/main/kotlin/com/gatehill/slackgateway/backend/slack/service/SlackOperationsService.kt
+++ b/backends/slack/src/main/kotlin/com/gatehill/slackgateway/backend/slack/service/SlackOperationsService.kt
@@ -22,7 +22,9 @@ import javax.inject.Inject
  *
  * @author Pete Cornish {@literal <outofcoffee@gmail.com>}
  */
-class SlackOperationsService @Inject constructor(private val slackApiService: SlackApiService) {
+class SlackOperationsService @Inject constructor(
+    private val slackApiService: SlackApiService
+) {
     private val logger: Logger = LogManager.getLogger(SlackOperationsService::class.java)
 
     private val cache = CacheBuilder.newBuilder()
@@ -51,7 +53,7 @@ class SlackOperationsService @Inject constructor(private val slackApiService: Sl
     private fun fetchUsers(): List<SlackUser> {
         logger.debug("Fetching all users")
 
-        val reply = slackApiService.invokeSlackCommand<UsersListResponse>(commandName = "users.list")
+        val reply = slackApiService.invokePaginatedSlackCommand<SlackUser, UsersListResponse>(commandName = "users.list")
         return reply.members
     }
 
@@ -69,7 +71,7 @@ class SlackOperationsService @Inject constructor(private val slackApiService: Sl
     internal fun listPrivateChannels(): List<SlackGroup> {
         logger.debug("Listing private channels")
 
-        val reply = slackApiService.invokeSlackCommand<GroupsListResponse>(commandName = "groups.list")
+        val reply = slackApiService.invokePaginatedSlackCommand<SlackGroup, GroupsListResponse>(commandName = "groups.list")
         return reply.groups ?: emptyList()
     }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,9 @@ services:
     build: ./distro
     ports:
       - "8080:8080"
+      # Java debug port
+      - "8000:8000"
     environment:
-      SLACK_USER_TOKEN: "CHANGEME"
-      SLACK_CHANNEL_MEMBERS: "jsmith,mjones"
+      - SLACK_USER_TOKEN
+      - SLACK_CHANNEL_MEMBERS
+      - JAVA_OPTS

--- a/docs/hacking.md
+++ b/docs/hacking.md
@@ -1,0 +1,26 @@
+# Local development
+
+Set required environment variables in a file name `.env` next to the Docker Compose file.
+
+    SLACK_USER_TOKEN=CHANGEME
+    SLACK_CHANNEL_MEMBERS=jsmith,mjones
+
+Build the distribution:
+
+    ./gradlew clean installdist
+
+Start the container locally:
+
+     docker-compose up --build --force-recreate
+
+Check it works:
+
+    curl http://localhost:8080/messages/text \
+            --data 'channel=bot-test' \
+            --data 'text=Hello%20World!'
+
+## Java debugger
+
+Set the `JAVA_OPTS` environment variable:
+
+    JAVA_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000


### PR DESCRIPTION
Fixes #1 

Paging is now supported for groups.list and users.list API calls.

Example:

```
12:15:14.940 DEBUG c.g.s.b.s.s.SlackOperationsService - Listing private channels
12:15:14.944 DEBUG c.g.s.b.s.s.SlackApiService - Invoking paged Slack API: groups.list [page 1]
12:15:16.035 DEBUG c.g.s.b.s.s.SlackApiService - Slack API: groups.list returned HTTP status: 200
12:15:17.271 DEBUG c.g.s.b.s.s.SlackApiService - Invoking paged Slack API: groups.list [page 2]
12:15:17.981 DEBUG c.g.s.b.s.s.SlackApiService - Slack API: groups.list returned HTTP status: 200
12:15:17.986 DEBUG c.g.s.b.s.s.SlackOutboundMessageService - Channel paging-test already exists
12:15:17.987 DEBUG c.g.s.b.s.s.SlackOutboundMessageService - Skipping check for participants of channel: paging-test (no participants are configured)
12:15:17.988 INFO  c.g.s.b.s.s.SlackOperationsService - Forwarding message to channel 'paging-test': {channel=paging-test, text=Hello world}
12:15:18.394 DEBUG c.g.s.b.s.s.SlackApiService - Slack API: chat.postMessage returned HTTP status: 200
```